### PR TITLE
Fix regex to make it BSD sed compatible

### DIFF
--- a/init-ansible-project.sh
+++ b/init-ansible-project.sh
@@ -25,7 +25,7 @@ done
 
 
 function write_out() {
-    sed -rn -e '/^={20}\s*'$1'/,/={20}/p' $0 |
+    sed -rn -e '/^={20}[[:space:]]*'"$1"'/,/={20}/p' $0 |
     sed -r -e 1d -e '$d' \
 	>$1
 


### PR DESCRIPTION
As sed on macOS does not have enhanced feature compiled in, things like
\s or \d are not supported. Therefore switch to bracket expression
counterpart.

Meanwhile BSD also feature the -r option for compatibility to GNU sed,
therefore no -E is needed anymore.

Fixes #1
